### PR TITLE
fix: update script links to Lock to latest major version on cdn (jQuery seed examples)

### DIFF
--- a/examples/pubnub-example/README.md
+++ b/examples/pubnub-example/README.md
@@ -18,3 +18,7 @@ Go to `http://localhost:3000` and you'll see the app running :).
 If you try to go to the chat without logging in, you'll see lots of `Fobidden` messages being shown. That's because you can't subscribe nor publish messages if you're not logged in. If you log in, then you'll be able to publish and receive messages!
 
 ![Chat app](https://cloudup.com/iRO8YbJL4-7+)
+
+## Updates for production
+
+Auth0's Lock library is available on CDN (default pointer in this project). See the [Lock repository README](https://github.com/auth0/lock#install) for instructions on getting the latest release version.

--- a/examples/pubnub-example/index.html
+++ b/examples/pubnub-example/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <script src="http://code.jquery.com/jquery-2.1.1.js"></script>
-        <script src="https://cdn.auth0.com/js/lock-7.12.min.js"></script>
+        <script src="http://cdn.auth0.com/js/lock-8.min.js"></script>
 
         <script src="//use.typekit.net/iws6ohy.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>

--- a/examples/sso-multiple-apps/README.md
+++ b/examples/sso-multiple-apps/README.md
@@ -5,3 +5,7 @@ You'll see that we have two different apps, one in the folder one and the other 
 Check [the first client id](https://github.com/auth0/auth0-jquery/blob/gh-pages/examples/sso-multiple-apps/one/app.js#L4) and [the second one](https://github.com/auth0/auth0-jquery/blob/gh-pages/examples/sso-multiple-apps/two/app.js#L4)
 
 However, if you go to http://auth0.github.io/auth0-jquery/ sso-multiple-apps/one/, login, and then go to http://auth0.github.io/auth0-jquery/ sso-multiple-apps/two/ (Or the other way around), you'll see that you're logged in in the second app without having to do anything.
+
+## Updates for production
+
+Auth0's Lock library is available on CDN (default pointer in this project). See the [Lock repository README](https://github.com/auth0/lock#install) for instructions on getting the latest release version.

--- a/examples/sso-multiple-apps/one/index.html
+++ b/examples/sso-multiple-apps/one/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="utf-8">
         <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-        <script src="https://cdn.auth0.com/js/lock-7.12.min.js"></script>
+        <script src="http://cdn.auth0.com/js/lock-8.min.js"></script>
 
         <script src="//use.typekit.net/iws6ohy.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>

--- a/examples/sso-multiple-apps/two/index.html
+++ b/examples/sso-multiple-apps/two/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="utf-8">
         <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-        <script src="https://cdn.auth0.com/js/lock-7.12.min.js"></script>
+        <script src="http://cdn.auth0.com/js/lock-8.min.js"></script>
 
         <script src="//use.typekit.net/iws6ohy.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>

--- a/examples/widget-with-api/README.md
+++ b/examples/widget-with-api/README.md
@@ -15,3 +15,7 @@ In order to run the example you need to just start a server. What we suggest is 
 3. run `serve` in the directory of this project.
 
 Go to `http://localhost:3000` and you'll see the app running :).
+
+## Updates for production
+
+Auth0's Lock library is available on CDN (default pointer in this project). See the [Lock repository README](https://github.com/auth0/lock#install) for instructions on getting the latest release version.

--- a/examples/widget-with-api/index.html
+++ b/examples/widget-with-api/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-        <script src="https://cdn.auth0.com/js/lock-7.12.min.js"></script>
+        <script src="http://cdn.auth0.com/js/lock-8.min.js"></script>
 
         <script src="//use.typekit.net/iws6ohy.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>

--- a/examples/widget-with-thirdparty-api/README.md
+++ b/examples/widget-with-thirdparty-api/README.md
@@ -15,3 +15,7 @@ In order to run the example you need to just start a server. What we suggest is 
 3. run `serve` in the directory of this project.
 
 Go to `http://localhost:3000` and you'll see the app running :).
+
+## Updates for production
+
+Auth0's Lock library is available on CDN (default pointer in this project). See the [Lock repository README](https://github.com/auth0/lock#install) for instructions on getting the latest release version.

--- a/examples/widget-with-thirdparty-api/index.html
+++ b/examples/widget-with-thirdparty-api/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <script src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
-        <script src="https://cdn.auth0.com/js/lock-7.12.min.js"></script>
+        <script src="http://cdn.auth0.com/js/lock-8.min.js"></script>
 
         <script src="//use.typekit.net/iws6ohy.js"></script>
         <script>try{Typekit.load();}catch(e){}</script>


### PR DESCRIPTION
doc: update README files with pointer to Lock repo README for getting latest version and production updates

this is related to an existing issue: https://github.com/auth0/docs/issues/52

I am interested in applying to a Developer + Technical Writer position and will send an application shortly. thanks.